### PR TITLE
- fix type annotation and use expected ARC4 types instead of python's…

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
… built-in str

## Algorand Coding Challenge Submission

**What was the bug?**

- type annotation in context of ARC4 types was not used correctly instead python's built-in str type was used

**How did you fix the bug?**

- you need to ensure that method parameters are typed correctly and use ARC4-specific types rather than python native types for parameters expected by ARC4 library components

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-4/assets/697392/2094ae06-5493-4491-9489-d167748c7a72)

