### PR TITLE
Fix types in VerifyMedicalAI.record_ai_info

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -1,4 +1,4 @@
-from algopy import ARC4Contract, arc4, LocalState, Txn, UInt64, Global, op
+from algopy import ARC4Contract, arc4, LocalState, Txn, Global, op
 
 
 class AiInfo(arc4.Struct):
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The ABI method `record_ai_info` of the `VerifyMedicalAI` smart contract was using incompatible types in the method signature.

**How did you fix the bug?**

Replaced the types with contract (ARC4) compatible types of the `arc4`  namespace.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-4/assets/1091843/13471bcf-a83a-42dd-aa3b-b241d7090e3e)

