### PR TITLE
Update record_ai_info parameters to use arc4 types.

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The record_ai_info function expected parameters of the arc4 library's specific types (e.g., arc4.String, arc4.UInt64, arc4.Bool) but was being called with standard Python string (str) and numeric types. This led to type incompatibility errors as indicated by the error messages.

Error Messages:

```
error: Argument "name" to "AiInfo" has incompatible type "str"; expected "String"
error: Argument "used_model" to "AiInfo" has incompatible type "str"; expected "String" 
...
```

**How did you fix the bug?**

I updated the record_ai_info function's parameter types to use the correct arc4 types. This ensures compatibility and allows for proper usage of arc4 library features.

**Console Screenshot:**

![Screenshot 2567-04-24 at 15 18 18](https://github.com/algorand-coding-challenges/python-challenge-4/assets/3756229/dc864db3-2f0b-4d88-8dc0-f6476d02c51b)


