### PR TITLE
Fix contract method's argument data typings

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The `smart_contracts/verify_medical_ai/contract.py::record_ai_info()` method had Python native data typings, which do not have built-in type conversions regarding Algorand's expected data types. Therefore, as Algorand could not understand the given values, it threw the following error:

```bash
Running `build` command in /home/algorambo/developments/algorand-challenges/python-challenge-4/projects/challenge...

····················· project run 'build' command output: ······················
2024-04-25 17:08:35,089 INFO      : Loading .env
2024-04-25 17:08:35,089 INFO      : Building app at smart_contracts/verify_medical_ai/contract.py
2024-04-25 17:08:35,090 INFO      : Exporting smart_contracts/verify_medical_ai/contract.py to /home/algorambo/developments/algorand-challenges/python-challenge-4/projects/challenge/smart_contracts/artifacts/verify_medical_ai
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/algorambo/developments/algorand-challenges/python-challenge-4/projects/challenge/smart_contracts/__main__.py", line 56, in <module>
    main(sys.argv[1])
  File "/home/algorambo/developments/algorand-challenges/python-challenge-4/projects/challenge/smart_contracts/__main__.py", line 34, in main
    build(artifact_path / contract.name, contract.path)
  File "/home/algorambo/developments/algorand-challenges/python-challenge-4/projects/challenge/smart_contracts/helpers/build.py", line 34, in build
    raise Exception(f"Could not build contract:\n{build_result.stdout}")
Exception: Could not build contract:
You are using AlgoKit version 2.0.2, however version 2.0.3 is available. Please update using the tool used to install AlgoKit.
info: Found python prefix: /home/algorambo/developments/algorand-challenges/python-challenge-4/projects/challenge/.venv
smart_contracts/verify_medical_ai/contract.py:39 error: Argument "name" to "AiInfo" has incompatible type "str"; expected "String"  [arg-type]
                                                                       name=name,
                                                                            ^~~~
smart_contracts/verify_medical_ai/contract.py:40 error: Argument "used_model" to "AiInfo" has incompatible type "str"; expected "String"  [arg-type]
                                                                       used_model=used_model,
                                                                                  ^~~~~~~~~~
smart_contracts/verify_medical_ai/contract.py:41 error: Argument "medical_degree" to "AiInfo" has incompatible type "str"; expected "String"  [arg-type]
                                                                       medical_degree=medical_degree,
                                                                                      ^~~~~~~~~~~~~~
smart_contracts/verify_medical_ai/contract.py:42 error: Argument "mcat_score" to "AiInfo" has incompatible type "UInt64"; expected "UIntN[Literal[64]]"  [arg-type]
                                                                       mcat_score=mcat_score,
                                                                                  ^~~~~~~~~~
smart_contracts/verify_medical_ai/contract.py:43 error: Argument "residency_training" to "AiInfo" has incompatible type "bool"; expected "Bool"  [arg-type]
                                                                       residency_training=residency_training,
                                                                                          ^~~~~~~~~~~~~~~~~~
smart_contracts/verify_medical_ai/contract.py:44 error: Argument "medical_license" to "AiInfo" has incompatible type "bool"; expected "Bool"  [arg-type]
                                                                       medical_license=medical_license,
                                                                                       ^~~~~~~~~~~~~~~

An error occurred during compile. Please ensure that any supplied arguments are valid and any files passed are valid Algorand Python code before retrying.


Error: 'build' failed executing 'poetry run python -m smart_contracts build' with exit code = 1
```

**How did you fix the bug?**

Simply replaced the Python native data typings with the expected arc4 data type constaints for the method arguments:

From:
```python
    @arc4.abimethod()
    def record_ai_info(
        self,
        name: str,
        used_model: str,
        medical_degree: str,
        mcat_score: UInt64,
        residency_training: bool,
        medical_license: bool,
    ) -> None:
       ...
```

To:
```python
    @arc4.abimethod()
    def record_ai_info(
        self,
        name: arc4.String,
        used_model: arc4.String,
        medical_degree: arc4.String,
        mcat_score: arc4.UInt64,
        residency_training: arc4.Bool,
        medical_license: arc4.Bool,
    ) -> None:
       ...
```

**Console Screenshot:**

<img width="953" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-4/assets/162426140/73173e1b-513a-4511-890e-d76ab96eecb9">

