### PR TITLE
[Fix] Wrong types used for AiInfo constructer

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The record_ai_info wait for parameters of types str, UInt64 and bool but those types are not valid for abi methods.

**How did you fix the bug?**

I replaced 'native' types by arc4 equivalents:
str -> arc4.String
UInt64 -> arc4.UInt64
bool -> arc4.Bool

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-4/assets/162464577/5553d376-a300-44e2-b6f6-d5d70a1f00ab)