### PR TITLE
Fix types of arc4 method arguments

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

`record_ai_info()` abi method of `VerifyMedicalAI` contract was declared with pure python argument types instead of arc4 types. This resulted in multiple `incompatible type` errors in contract build phase.

<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**

Replacing arguments types for arc4 counterparts (e.g. str -> arc4.String) fixed the bug.
<!-- Explain the steps you took to fix the bug. -->

**Console Screenshot:**
![python_challenge_4](https://github.com/algorand-coding-challenges/python-challenge-4/assets/114208957/593df4a5-1a5b-46bb-873e-5e19d9af40d2)

<!-- Attach a screenshot of your console showing the result specified in the README. -->
