### PR TITLE
Fix type mismatch in smart contract function signatures

### DIFF
--- a/projects/challenge/smart_contracts/verify_medical_ai/contract.py
+++ b/projects/challenge/smart_contracts/verify_medical_ai/contract.py
@@ -28,12 +28,12 @@ class VerifyMedicalAI(ARC4Contract):
     @arc4.abimethod()
     def record_ai_info(
         self,
-        name: str,
-        used_model: str,
-        medical_degree: str,
-        mcat_score: UInt64,
-        residency_training: bool,
-        medical_license: bool,
+        name: arc4.String,
+        used_model: arc4.String,
+        medical_degree: arc4.String,
+        mcat_score: arc4.UInt64,
+        residency_training: arc4.Bool,
+        medical_license: arc4.Bool,
     ) -> None:
         self.ai_info[Txn.sender] = AiInfo(
             name=name,


### PR DESCRIPTION
**1) What was the problem?**

The problem was related to type mismatches in the `record_ai_info` method signatures of the `VerifyMedicalAI` smart contract. The method signatures were initially defined using basic Python types such as `str`, `bool`, and `UInt64`. This led to compile-time errors because the ARC4 framework requires using ARC4-specific types (like `arc4.String`, `arc4.Bool`, and `arc4.UInt64`) for both defining data structures and for function parameters to maintain type safety and adhere to ARC4's strict type system. The errors were preventing the smart contract from being built, as ARC4 could not correctly interpret these basic Python types in the context of ARC4's static type checking.

**2) How did you solve the problem?**

I solved the problem by updating the `record_ai_info` method's parameter types from Python's built-in types to ARC4-specific types. This involved changing the function signatures to expect `arc4.String`, `arc4.UInt64`, and `arc4.Bool` directly, rather than the standard Python `str`, `bool`, and `UInt64`. By aligning the method signatures with the types used in the `AiInfo` struct, I ensured type consistency and compatibility across the contract. This change addressed the build errors by satisfying ARC4's type requirements, allowing the contract to compile successfully and ensuring that all operations within the contract adhere to the expected type safety standards of ARC4.

**3) Screenshot of your terminal showing the result of running the deploy script.** 

![python-challenge-4-jeff-stein-5-10-24](https://github.com/algorand-coding-challenges/python-challenge-4/assets/105945985/cdc730a4-2c97-458b-b554-6ce8ba04dde9)

